### PR TITLE
SPT-4536: Bugfix for additional list type condition

### DIFF
--- a/src/QSwagGenerator/QSwagGenerator.csproj
+++ b/src/QSwagGenerator/QSwagGenerator.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>QSwag is a complete swagger generator for .NET</Description>
     <AssemblyTitle>QSwag Generator</AssemblyTitle>
-    <VersionPrefix>1.0.13</VersionPrefix>
+    <VersionPrefix>1.0.14</VersionPrefix>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>QSwagGenerator</AssemblyName>
@@ -16,8 +16,8 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.0.13</Version>
-    <AssemblyVersion>1.0.13.0</AssemblyVersion>
+    <Version>1.0.14</Version>
+    <AssemblyVersion>1.0.14.0</AssemblyVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Dmitriy Krasnikov, Jon Ford, Alex Bainter</Authors>
     <Company>Swimlane</Company>

--- a/src/QSwagTest/Include/ComplexEnumerableType.json
+++ b/src/QSwagTest/Include/ComplexEnumerableType.json
@@ -1,0 +1,100 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "QSwag Test API",
+    "version": "1.0"
+  },
+  "schemes": [
+    "http"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/api/ComplexListType/packageddescriptor/{id}": {
+      "get": {
+        "tags": [
+          "complexEnumerableType"
+        ],
+        "operationId": "getPackagedDescriptor",
+        "parameters": [
+          {
+            "name": "id",
+            "description": "",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/QSwagWebApi.Models.PackagedDescriptor"
+            }
+          },
+          "default": {
+            "description": "Unexpected Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "QSwagWebApi.Models.PackagedDescriptor": {
+      "properties": {
+        "installRequires": {
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "type": "array"
+        },
+        "packages": {
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ErrorModel": {
+      "description": "Default Error Object",
+      "required": [
+        "message",
+        "code"
+      ],
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "code": {
+          "maximum": 600.0,
+          "minimum": 100.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "securityDefinitions": {
+    "jwt_token": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "jwt_token": []
+    }
+  ]
+}

--- a/src/QSwagTest/WebApiTest.cs
+++ b/src/QSwagTest/WebApiTest.cs
@@ -32,10 +32,10 @@ namespace QSwagTest
             {
                 license = Environment.GetEnvironmentVariable("Newtonsoft");
             }
-            catch(ArgumentNullException)
+            catch (ArgumentNullException)
             {
-                
             }
+
             return license;
         }
 
@@ -90,12 +90,20 @@ namespace QSwagTest
                     _xmlDocPath));
             AssertEqualIgnoreWhitespace("Duplicate method name.", exception.Message);
         }
-        
+
         [Fact]
         public void CheckComplexListType()
         {
             var result = Controller.GetSwagger("ComplexListType", _xmlDocPath);
             var expected = File.ReadAllText(Path.Combine("Include", "ComplexListType.json"));
+            AssertEqualIgnoreWhitespace(expected, result);
+        }
+
+        [Fact]
+        public void CheckComplexEnumerableType()
+        {
+            var result = Controller.GetSwagger("ComplexEnumerableType", _xmlDocPath);
+            var expected = File.ReadAllText(Path.Combine("Include", "ComplexEnumerableType.json"));
             AssertEqualIgnoreWhitespace(expected, result);
         }
 

--- a/src/QSwagWebApi/Controllers/ComplexEnumerableTypeController.cs
+++ b/src/QSwagWebApi/Controllers/ComplexEnumerableTypeController.cs
@@ -8,14 +8,14 @@ using QSwagWebApi.Models;
 namespace QSwagWebApi.Controllers
 {
     [Route("api/ComplexListType")]
-    public class ComplexListTypeController : Controller
+    public class ComplexEnumerableTypeController : Controller
     {
         #region Access: Public
-
-        [HttpGet("chartsort/{id}")]
-        public ChartSort GetChartSort(int id)
+        
+        [HttpGet("packageddescriptor/{id}")]
+        public PackagedDescriptor GetPackagedDescriptor(int id)
         {
-            return new ChartSort();
+            return new PackagedDescriptor();
         }
 
         #endregion

--- a/src/QSwagWebApi/Models/PackagedDescriptor.cs
+++ b/src/QSwagWebApi/Models/PackagedDescriptor.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace QSwagWebApi.Models
+{
+    public class PackagedDescriptor
+    {
+        public IEnumerable<string> InstallRequires { get; set; }
+
+        public IEnumerable<string> Packages { get; set; }
+    }
+}


### PR DESCRIPTION
The solution from the last PR did not fix the generation bug for IEnumerable<string> or any other non-object type. The real solution was to check for `property.Type.Value.HasFlag(JSchemaType.Object)` in addition to checking if `processedDefinitions.Contains(property.Id)`. Added an additional test to cover this case. 1.0.13 has already been published so needed to bump the version again.